### PR TITLE
Convert router output to Enum

### DIFF
--- a/agents_enum.py
+++ b/agents_enum.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class Agent(Enum):
+    SQL_DB_AGENT = "sql_db_agent"
+    VECTOR_DB_AGENT = "vector_db_agent"
+    WEB_SEARCH_AGENT = "web_search_agent"
+    GENERATE = "generate"


### PR DESCRIPTION
To address the unintended occurrence of preamble during routing, the output type has been converted to an Enum of agent names using EnumOutputParser. closes #1